### PR TITLE
Fix build with GCC 11

### DIFF
--- a/mak/general.mak
+++ b/mak/general.mak
@@ -8,5 +8,5 @@ LFLAGS =
 ifdef DEBUG
 CFLAGS = -g -O0
 else
-CFLAGS = -O2
+CFLAGS = -fPIC -O2 -fpermissive
 endif

--- a/sdlplay.c
+++ b/sdlplay.c
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <stdio.h>
 #include <SDL.h>
 


### PR DESCRIPTION
While working on https://github.com/Homebrew/homebrew-core/pull/106629, we identified a couple of minor issues when building with GCC 11.  These changes also work on macOS so they should be okay to use unconditionally.